### PR TITLE
feat: update share links to include LinkedIn and remove Pinterest

### DIFF
--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -25,15 +25,20 @@ const shareLinks = [
     href: "https://t.me/share/url?url=",
     linkTitle: `Share this post via Telegram`,
   },
-  {
-    name: "Pinterest",
-    href: "https://pinterest.com/pin/create/button/?url=",
-    linkTitle: `Share this post on Pinterest`,
-  },
+  // {
+  //   name: "Pinterest",
+  //   href: "https://pinterest.com/pin/create/button/?url=",
+  //   linkTitle: `Share this post on Pinterest`,
+  // },
   {
     name: "Mail",
     href: "mailto:?subject=See%20this%20post&body=",
     linkTitle: `Share this post via email`,
+  },
+  {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/sharing/share-offsite/?url=",
+    linkTitle: "Share this post on LinkedIn",
   },
 ] as const;
 ---


### PR DESCRIPTION
Removes the Pinterest share link and adds a LinkedIn share link to the 
ShareLinks component. This change enhances sharing options by providing 
a more relevant platform for users while decluttering the list of 
available share links.